### PR TITLE
Use bash because this is a bash script

### DIFF
--- a/docker-compose-consul/build_images.sh
+++ b/docker-compose-consul/build_images.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
  cd ${PWD}/images/
  for folder in *; do


### PR DESCRIPTION
Using bash prevents this script from erroring with `./build_images.sh: 5: [[: not found`.