### PR TITLE
docs: added the ACL token in the README

### DIFF
--- a/docker-compose-consul/README.md
+++ b/docker-compose-consul/README.md
@@ -9,7 +9,7 @@ To get started, please follow the steps below.
 
 ## Requirements
 
-- Docker
+- Docker v20.10.8+
 
 ## Create images
 
@@ -29,7 +29,12 @@ docker-compose up --detach
 
 **NOTE**: It takes approximately 10-15 seconds for all services to come up.
 
-Visit the Consul dashboard at http://localhost:8500 and ensure all services are up. 
+Visit the Consul dashboard at http://localhost:8500 and ensure all services are up.  
+To access the Consul UI use the following ACL token: 
+
+```
+20d16fb2-9bd6-d238-bfdc-1fab80177667
+```
 
 Next, go to http://localhost:80 to visit HashiCups.
 

--- a/docker-compose-consul/install.sh
+++ b/docker-compose-consul/install.sh
@@ -2,7 +2,7 @@
 
 # This is ensure sufficient time is provided for ACLs to replicate to the secondary Consul DC
 if [ $SECONDARY == true ]; then
-   sleep 8
+   sleep 10
 fi
 
 if [ $SERVICE != product-db ]; then


### PR DESCRIPTION
This PR adds the ACL token to the README for the Consul Docker Compose example.