### PR TITLE
fix: missing localhost for frontend

### DIFF
--- a/docker-compose-consul/docker-compose.yaml
+++ b/docker-compose-consul/docker-compose.yaml
@@ -287,7 +287,7 @@ services:
     ports:
       - '3030:3000'
     environment:
-      - NEXT_PUBLIC_PUBLIC_API_URL=http://public-api:8080
+      - NEXT_PUBLIC_PUBLIC_API_URL=http://localhost:8080 # If using Tproxy use the DNS name such as http://public-api:8080
       - SERVICE=frontend
       - CONSUL_HTTP_ADDR=http://127.0.0.1:8500
       - CONSUL_HTTP_TOKEN=20d16fb2-9bd6-d238-bfdc-1fab80177667


### PR DESCRIPTION
Added localhost to the frontend config for `public-api`