### PR TITLE
Add example for NGINX as reverse proxy for frontend

### DIFF
--- a/docker-compose-deployment-reverse-proxy-nginx/README.md
+++ b/docker-compose-deployment-reverse-proxy-nginx/README.md
@@ -1,0 +1,20 @@
+## Docker Compose Local Setup
+
+This deploys HashiCups locally through Docker Compose. HashiCups is unsecured by default. If you are looking for a secure version of HashiCups please see the folder [docker-compose-consul](../docker-compose-consul/README.md)
+
+## Deploying HashiCups
+
+Navigate to this folder using your CLI and run the following.
+
+```
+docker compose up -d
+```
+
+## Clean-up
+
+Run the following command to clean up and remove the HashiCups resources.
+
+```
+docker compose down
+```
+

--- a/docker-compose-deployment-reverse-proxy-nginx/conf.json
+++ b/docker-compose-deployment-reverse-proxy-nginx/conf.json
@@ -1,0 +1,5 @@
+{
+    "db_connection": "host=product-db port=5432 user=postgres password=password dbname=products sslmode=disable",
+    "bind_address": ":9090",
+    "metrics_address": ":9103"
+  }

--- a/docker-compose-deployment-reverse-proxy-nginx/docker-compose.yaml
+++ b/docker-compose-deployment-reverse-proxy-nginx/docker-compose.yaml
@@ -1,11 +1,19 @@
 version: '3.8'
 services:
   frontend:
-    image: 'hashicorpdemoapp/frontend:v0.0.8'
+    image: 'hashicorpdemoapp/frontend:v1.0.1'
     environment:
-      - NEXT_PUBLIC_PUBLIC_API_URL=http://public-api:8080
+      - NEXT_PUBLIC_PUBLIC_API_URL=http://localhost
+  nginx:
+    image: nginx:alpine
+    links:
+      - 'public-api:public-api'
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/conf.d/default.conf
     ports:
-      - '80:3000'
+      - 80:80
   public-api:
     image: 'hashicorpdemoapp/public-api:v0.0.6'
     environment:

--- a/docker-compose-deployment-reverse-proxy-nginx/nginx.conf
+++ b/docker-compose-deployment-reverse-proxy-nginx/nginx.conf
@@ -1,0 +1,49 @@
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=7d use_temp_path=off;
+
+upstream frontend_upstream {
+  server frontend:3000;
+}
+
+server {
+  listen 80;
+  server_name  localhost;
+
+  server_tokens off;
+
+  gzip on;
+  gzip_proxied any;
+  gzip_comp_level 4;
+  gzip_types text/css application/javascript image/svg+xml;
+
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection 'upgrade';
+  proxy_set_header Host $host;
+  proxy_cache_bypass $http_upgrade;
+
+  location /_next/static {
+    proxy_cache STATIC;
+    proxy_pass http://frontend_upstream;
+
+    # For testing cache - remove before deploying to production
+    add_header X-Cache-Status $upstream_cache_status;
+  }
+
+  location /static {
+    proxy_cache STATIC;
+    proxy_ignore_headers Cache-Control;
+    proxy_cache_valid 60m;
+    proxy_pass http://frontend_upstream;
+
+    # For testing cache - remove before deploying to production
+    add_header X-Cache-Status $upstream_cache_status;
+  }
+
+  location / {
+    proxy_pass http://frontend_upstream;
+  }
+
+  location /api {
+    proxy_pass http://public-api:8080;
+  }
+}


### PR DESCRIPTION
This adds an example for NGINX as a reverse proxy for the HashiCups frontend (`docker-compose-deployment-reverse-proxy-nginx`). Since NGNIX is serving the frontend through the server, you can use it with Consul transparent proxy

The `nginx.conf` implementation is very similar to the previous one, but uses a dedicated NGINX container as a reverse proxy rather than it being built into the frontend container. I think this is a better approach, since it makes the architecture more modular.

Because the frontend container is still running through `next start`, refreshes work as expected.

For reverse proxy, `NEXT_PUBLIC_PUBLIC_API_URL` must be `http://localhost` since the NGINX container is proxying `/api` to the `public-api` container.

```
links:
    - 'public-api:public-api'
```

```
location /api {
  proxy_pass http://public-api:8080;
}
```