### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose-deployment/docker-compose.yaml
+++ b/docker-compose-deployment/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   frontend:
-    image: 'hashicorpdemoapp/frontend:v0.0.8'
+    image: 'hashicorpdemoapp/frontend:v1.0.3'
     environment:
       - NEXT_PUBLIC_PUBLIC_API_URL=http://public-api:8080
     ports:


### PR DESCRIPTION
Need to update to later version of frontend container v1.0.3 to support environment variable NEXT_PUBLIC_PUBLIC_API_URL.  Didn't work for v0.0.8.  It had an issue where it was calling the apis using http://localhost:8080.