### PR TITLE
fix: added ECS example of HashiCups w/ HCP Consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Current Options
 * [Docker Compose](docker-compose-deployment/README.md) 
 * [Docker Compose w/ Consul and Envoy](docker-compose-consul/README.md)
 * [Local K8s deployment using kind and Consul](local-k8s-consul-deployment/README.md)
-* [AWS ECS with HCP](terraform-aws-hcp-ecs/README.md)
+* [AWS ECS with HCP](lterraform-ecs-hcp/README.md)
+* [AWS ECS with HCP + Boundary](terraform-aws-hcp-ecs/README.md)
 * [Nomad](nomad/README.md)
 
 Navigate to the appropriate folder and follow the README.

--- a/terraform-ecs-hcp/README.md
+++ b/terraform-ecs-hcp/README.md
@@ -1,0 +1,86 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >3.0.0 |
+| <a name="requirement_consul"></a> [consul](#requirement\_consul) | ~> 2.15.0 |
+| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.14.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >3.0.0 |
+| <a name="provider_consul"></a> [consul](#provider\_consul) | ~> 2.15.0 |
+| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | ~> 0.14.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acl_controller"></a> [acl\_controller](#module\_acl\_controller) | registry.terraform.io/hashicorp/consul-ecs/aws//modules/acl-controller | 0.4.0 |
+| <a name="module_hashicups-tasks"></a> [hashicups-tasks](#module\_hashicups-tasks) | registry.terraform.io/hashicorp/consul-ecs/aws//modules/mesh-task | 0.4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | registry.terraform.io/terraform-aws-modules/vpc/aws | 2.78.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_service.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_iam_policy.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.example_client_app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_route.private_to_hvn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.public_to_hvn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_secretsmanager_secret.bootstrap_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.consul_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.gossip_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.bootstrap_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.consul_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.gossip_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.example_client_app_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.ingress_from_client_alb_to_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_vpc_peering_connection_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
+| [consul_config_entry.deny_all](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.payments_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.postgres_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.product-api](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.product_api_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.public_api_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [hcp_aws_network_peering.default](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/aws_network_peering) | resource |
+| [hcp_consul_cluster.example](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/consul_cluster) | resource |
+| [hcp_hvn.server](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn) | resource |
+| [hcp_hvn_route.peering_route](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn_route) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_ecs_task_definition.tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
+| [aws_security_group.vpc_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_logs_group"></a> [aws\_logs\_group](#input\_aws\_logs\_group) | n/a | `string` | `"hashicups"` | no |
+| <a name="input_capacity_providers"></a> [capacity\_providers](#input\_capacity\_providers) | n/a | `list(string)` | <pre>[<br>  "FARGATE"<br>]</pre> | no |
+| <a name="input_cluster_cidrs"></a> [cluster\_cidrs](#input\_cluster\_cidrs) | n/a | `any` | <pre>{<br>  "ecs_cluster": {<br>    "cidr_block": "10.0.0.0/16",<br>    "name": "ecs_cluster_one",<br>    "private_subnets": [<br>      "10.0.1.0/24",<br>      "10.0.2.0/24",<br>      "10.0.3.0/24"<br>    ],<br>    "public_subnets": [<br>      "10.0.4.0/24",<br>      "10.0.5.0/24",<br>      "10.0.6.0/24"<br>    ]<br>  }<br>}</pre> | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default Tags for AWS | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Team": "Education-Consul",<br>  "tutorial": "Serverless Consul service mesh with ECS and HCP"<br>}</pre> | no |
+| <a name="input_ecs_clusters"></a> [ecs\_clusters](#input\_ecs\_clusters) | n/a | `list` | <pre>[<br>  {<br>    "name": "cluster-one"<br>  },<br>  {<br>    "name": "cluster-two"<br>  }<br>]</pre> | no |
+| <a name="input_hashicups_settings"></a> [hashicups\_settings](#input\_hashicups\_settings) | n/a | `list` | <pre>[<br>  {<br>    "environment": [],<br>    "image": "hashicorpdemoapp/frontend:v1.0.3",<br>    "name": "frontend",<br>    "portMappings": [<br>      {<br>        "containerPort": 3000,<br>        "hostPort": 3000,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "public-api",<br>        "localBindPort": 8081<br>      }<br>    ]<br>  },<br>  {<br>    "environment": [],<br>    "image": "hashicorpdemoapp/payments:v0.0.16",<br>    "name": "payments",<br>    "portMappings": [<br>      {<br>        "containerPort": 8080,<br>        "hostPort": 8080,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "POSTGRES_DB",<br>        "value": "products"<br>      },<br>      {<br>        "name": "POSTGRES_USER",<br>        "value": "postgres"<br>      },<br>      {<br>        "name": "POSTGRES_PASSWORD",<br>        "value": "password"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/product-api-db:v0.0.21",<br>    "name": "postgres",<br>    "portMappings": [<br>      {<br>        "containerPort": 5432,<br>        "hostPort": 5432,<br>        "protocol": "tcp"<br>      }<br>    ],<br>    "upstreams": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "DB_CONNECTION",<br>        "value": "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable"<br>      },<br>      {<br>        "name": "METRICS_ADDRESS",<br>        "value": ":9103"<br>      },<br>      {<br>        "name": "BIND_ADDRESS",<br>        "value": ":9090"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/product-api:v0.0.21",<br>    "name": "product-api",<br>    "portMappings": [<br>      {<br>        "containerPort": 9090,<br>        "hostPort": 9090,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "postgres",<br>        "localBindPort": 5432<br>      }<br>    ],<br>    "volumes": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "BIND_ADDRESS",<br>        "value": ":8081"<br>      },<br>      {<br>        "name": "PRODUCT_API_URI",<br>        "value": "http://localhost:9090"<br>      },<br>      {<br>        "name": "PAYMENT_API_URI",<br>        "value": "http://localhost:1800"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/public-api:v0.0.6",<br>    "name": "public-api",<br>    "portMappings": [<br>      {<br>        "containerPort": 8081,<br>        "hostPort": 8081,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "product-api",<br>        "localBindPort": 9090<br>      }<br>    ]<br>  }<br>]</pre> | no |
+| <a name="input_hcp_datacenter_name"></a> [hcp\_datacenter\_name](#input\_hcp\_datacenter\_name) | The name of datacenter the Consul cluster belongs to | `string` | `"dc1"` | no |
+| <a name="input_hvn_settings"></a> [hvn\_settings](#input\_hvn\_settings) | n/a | `map` | <pre>{<br>  "cidr_block": "172.25.16.0/20",<br>  "cloud_provider": {<br>    "aws": "aws"<br>  },<br>  "name": {<br>    "main-hvn": "main-hvn"<br>  },<br>  "region": {<br>    "us-east-1": "us-east-1"<br>  }<br>}</pre> | no |
+| <a name="input_lb_ingress_ip"></a> [lb\_ingress\_ip](#input\_lb\_ingress\_ip) | Your Public IP. This is used in the load balancer security groups to ensure only you can access the Consul UI and example application. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier. | `string` | `"consul-ecs-hashicups"` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `"us-east-1"` | no |
+| <a name="input_target_group_settings"></a> [target\_group\_settings](#input\_target\_group\_settings) | n/a | `map` | <pre>{<br>  "elb": {<br>    "services": [<br>      {<br>        "deregistration_delay": 30,<br>        "health": {<br>          "healthy_threshold": 2,<br>          "interval": 30,<br>          "path": "/",<br>          "timeout": 29,<br>          "unhealthy_threshold": 2<br>        },<br>        "name": "frontend",<br>        "port": "80",<br>        "protocol": "HTTP",<br>        "service_type": "http",<br>        "target_group_type": "ip"<br>      },<br>      {<br>        "deregistration_delay": 30,<br>        "health": {<br>          "healthy_threshold": 2,<br>          "interval": 30,<br>          "path": "/",<br>          "port": "8081",<br>          "timeout": 29,<br>          "unhealthy_threshold": 2<br>        },<br>        "name": "public-api",<br>        "port": "8081",<br>        "protocol": "HTTP",<br>        "service_type": "http",<br>        "target_group_type": "ip"<br>      }<br>    ]<br>  }<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_client_lb_address"></a> [client\_lb\_address](#output\_client\_lb\_address) | n/a |
+| <a name="output_consul_ui_address"></a> [consul\_ui\_address](#output\_consul\_ui\_address) | n/a |

--- a/terraform-ecs-hcp/README.md
+++ b/terraform-ecs-hcp/README.md
@@ -1,86 +1,75 @@
+## Terraform ECS + HCP Consul
+
+This solution deploys HashiCups into AWS ECS while using HCP Consul as the service mesh solution.  This solution is different from [terraform-aws-hcp-ecs](../terraform-aws-hcp-ecs/README.md) as it only uses the HashiCups containers. 
+
+For more details on the Terraform code and required values, read [terraform.md](./Terraform.md).
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >3.0.0 |
-| <a name="requirement_consul"></a> [consul](#requirement\_consul) | ~> 2.15.0 |
-| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.14.0 |
+- Terraform 1.0.0+
+- AWS Account
+- IAM Permissions to deploy
+- - ECS Cluster
+- - Secrets Manager Secrets
+- - Create IAM ECS Task  roles
+- - Deploy a VPC
 
-## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >3.0.0 |
-| <a name="provider_consul"></a> [consul](#provider\_consul) | ~> 2.15.0 |
-| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | ~> 0.14.0 |
+## AWS & HCP Credentials
 
-## Modules
+To deploy this Terraform configuration you will need to setup your AWS and HCP credentials.
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_acl_controller"></a> [acl\_controller](#module\_acl\_controller) | registry.terraform.io/hashicorp/consul-ecs/aws//modules/acl-controller | 0.4.0 |
-| <a name="module_hashicups-tasks"></a> [hashicups-tasks](#module\_hashicups-tasks) | registry.terraform.io/hashicorp/consul-ecs/aws//modules/mesh-task | 0.4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | registry.terraform.io/terraform-aws-modules/vpc/aws | 2.78.0 |
 
-## Resources
+HCP Credentials can be set as ENV variables.
 
-| Name | Type |
-|------|------|
-| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_service.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
-| [aws_iam_policy.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_lb.example_client_app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
-| [aws_lb_listener.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_route.private_to_hvn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
-| [aws_route.public_to_hvn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
-| [aws_secretsmanager_secret.bootstrap_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.consul_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.gossip_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_version.bootstrap_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.consul_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.gossip_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_security_group.example_client_app_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.ingress_from_client_alb_to_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_vpc_peering_connection_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
-| [consul_config_entry.deny_all](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
-| [consul_config_entry.payments_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
-| [consul_config_entry.postgres_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
-| [consul_config_entry.product-api](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
-| [consul_config_entry.product_api_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
-| [consul_config_entry.public_api_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
-| [hcp_aws_network_peering.default](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/aws_network_peering) | resource |
-| [hcp_consul_cluster.example](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/consul_cluster) | resource |
-| [hcp_hvn.server](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn) | resource |
-| [hcp_hvn_route.peering_route](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn_route) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_ecs_task_definition.tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
-| [aws_security_group.vpc_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+```shell
+export HCP_CLIENT_ID=124asfd.....
+export HCP_CLIENT_SECRET=4gh48as.... 
+```
 
-## Inputs
+Next, set your AWS credentials as ENV variables.
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_aws_logs_group"></a> [aws\_logs\_group](#input\_aws\_logs\_group) | n/a | `string` | `"hashicups"` | no |
-| <a name="input_capacity_providers"></a> [capacity\_providers](#input\_capacity\_providers) | n/a | `list(string)` | <pre>[<br>  "FARGATE"<br>]</pre> | no |
-| <a name="input_cluster_cidrs"></a> [cluster\_cidrs](#input\_cluster\_cidrs) | n/a | `any` | <pre>{<br>  "ecs_cluster": {<br>    "cidr_block": "10.0.0.0/16",<br>    "name": "ecs_cluster_one",<br>    "private_subnets": [<br>      "10.0.1.0/24",<br>      "10.0.2.0/24",<br>      "10.0.3.0/24"<br>    ],<br>    "public_subnets": [<br>      "10.0.4.0/24",<br>      "10.0.5.0/24",<br>      "10.0.6.0/24"<br>    ]<br>  }<br>}</pre> | no |
-| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default Tags for AWS | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Team": "Education-Consul",<br>  "tutorial": "Serverless Consul service mesh with ECS and HCP"<br>}</pre> | no |
-| <a name="input_ecs_clusters"></a> [ecs\_clusters](#input\_ecs\_clusters) | n/a | `list` | <pre>[<br>  {<br>    "name": "cluster-one"<br>  },<br>  {<br>    "name": "cluster-two"<br>  }<br>]</pre> | no |
-| <a name="input_hashicups_settings"></a> [hashicups\_settings](#input\_hashicups\_settings) | n/a | `list` | <pre>[<br>  {<br>    "environment": [],<br>    "image": "hashicorpdemoapp/frontend:v1.0.3",<br>    "name": "frontend",<br>    "portMappings": [<br>      {<br>        "containerPort": 3000,<br>        "hostPort": 3000,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "public-api",<br>        "localBindPort": 8081<br>      }<br>    ]<br>  },<br>  {<br>    "environment": [],<br>    "image": "hashicorpdemoapp/payments:v0.0.16",<br>    "name": "payments",<br>    "portMappings": [<br>      {<br>        "containerPort": 8080,<br>        "hostPort": 8080,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "POSTGRES_DB",<br>        "value": "products"<br>      },<br>      {<br>        "name": "POSTGRES_USER",<br>        "value": "postgres"<br>      },<br>      {<br>        "name": "POSTGRES_PASSWORD",<br>        "value": "password"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/product-api-db:v0.0.21",<br>    "name": "postgres",<br>    "portMappings": [<br>      {<br>        "containerPort": 5432,<br>        "hostPort": 5432,<br>        "protocol": "tcp"<br>      }<br>    ],<br>    "upstreams": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "DB_CONNECTION",<br>        "value": "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable"<br>      },<br>      {<br>        "name": "METRICS_ADDRESS",<br>        "value": ":9103"<br>      },<br>      {<br>        "name": "BIND_ADDRESS",<br>        "value": ":9090"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/product-api:v0.0.21",<br>    "name": "product-api",<br>    "portMappings": [<br>      {<br>        "containerPort": 9090,<br>        "hostPort": 9090,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "postgres",<br>        "localBindPort": 5432<br>      }<br>    ],<br>    "volumes": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "BIND_ADDRESS",<br>        "value": ":8081"<br>      },<br>      {<br>        "name": "PRODUCT_API_URI",<br>        "value": "http://localhost:9090"<br>      },<br>      {<br>        "name": "PAYMENT_API_URI",<br>        "value": "http://localhost:1800"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/public-api:v0.0.6",<br>    "name": "public-api",<br>    "portMappings": [<br>      {<br>        "containerPort": 8081,<br>        "hostPort": 8081,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "product-api",<br>        "localBindPort": 9090<br>      }<br>    ]<br>  }<br>]</pre> | no |
-| <a name="input_hcp_datacenter_name"></a> [hcp\_datacenter\_name](#input\_hcp\_datacenter\_name) | The name of datacenter the Consul cluster belongs to | `string` | `"dc1"` | no |
-| <a name="input_hvn_settings"></a> [hvn\_settings](#input\_hvn\_settings) | n/a | `map` | <pre>{<br>  "cidr_block": "172.25.16.0/20",<br>  "cloud_provider": {<br>    "aws": "aws"<br>  },<br>  "name": {<br>    "main-hvn": "main-hvn"<br>  },<br>  "region": {<br>    "us-east-1": "us-east-1"<br>  }<br>}</pre> | no |
-| <a name="input_lb_ingress_ip"></a> [lb\_ingress\_ip](#input\_lb\_ingress\_ip) | Your Public IP. This is used in the load balancer security groups to ensure only you can access the Consul UI and example application. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier. | `string` | `"consul-ecs-hashicups"` | no |
-| <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `"us-east-1"` | no |
-| <a name="input_target_group_settings"></a> [target\_group\_settings](#input\_target\_group\_settings) | n/a | `map` | <pre>{<br>  "elb": {<br>    "services": [<br>      {<br>        "deregistration_delay": 30,<br>        "health": {<br>          "healthy_threshold": 2,<br>          "interval": 30,<br>          "path": "/",<br>          "timeout": 29,<br>          "unhealthy_threshold": 2<br>        },<br>        "name": "frontend",<br>        "port": "80",<br>        "protocol": "HTTP",<br>        "service_type": "http",<br>        "target_group_type": "ip"<br>      },<br>      {<br>        "deregistration_delay": 30,<br>        "health": {<br>          "healthy_threshold": 2,<br>          "interval": 30,<br>          "path": "/",<br>          "port": "8081",<br>          "timeout": 29,<br>          "unhealthy_threshold": 2<br>        },<br>        "name": "public-api",<br>        "port": "8081",<br>        "protocol": "HTTP",<br>        "service_type": "http",<br>        "target_group_type": "ip"<br>      }<br>    ]<br>  }<br>}</pre> | no |
+```shell
+export AWS_ACCESS_KEY_ID=48dafde....
+export AWS_SECRET_ACCESS_KEY=wJalas.....
+export AWS_DEFAULT_REGION=us-east-1
+```
 
-## Outputs
+**NOTE**: You may have to set the `AWS_SESSION_TOKEN` if your are consuming credentials from AWS STS.
 
-| Name | Description |
-|------|-------------|
-| <a name="output_client_lb_address"></a> [client\_lb\_address](#output\_client\_lb\_address) | n/a |
-| <a name="output_consul_ui_address"></a> [consul\_ui\_address](#output\_consul\_ui\_address) | n/a |
+
+
+## Deploy Terraform
+
+Create your own `terraform.tfvars` file to get started.
+
+```shell
+touch terraform.tfvars
+```
+
+Copy the valus from the `terraform.tfvars.example` file over to your `terraform.tfvars` file. Make changes as you see fit.
+
+Next, initialize the terraform directory.
+
+```shell
+terraform init
+```
+
+To preview the changes, issue the command `terraform plan`
+
+
+Lastly, to deploy the solution issue the command below.
+
+
+```
+terraform apply -auto-approve
+```
+
+
+## Clean-up
+
+To remove all resources issue the command below.
+
+```
+terraform destroy -auto-approve
+```

--- a/terraform-ecs-hcp/Terraform.md
+++ b/terraform-ecs-hcp/Terraform.md
@@ -1,0 +1,86 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >3.0.0 |
+| <a name="requirement_consul"></a> [consul](#requirement\_consul) | ~> 2.15.0 |
+| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.14.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >3.0.0 |
+| <a name="provider_consul"></a> [consul](#provider\_consul) | ~> 2.15.0 |
+| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | ~> 0.14.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acl_controller"></a> [acl\_controller](#module\_acl\_controller) | registry.terraform.io/hashicorp/consul-ecs/aws//modules/acl-controller | 0.4.0 |
+| <a name="module_hashicups-tasks"></a> [hashicups-tasks](#module\_hashicups-tasks) | registry.terraform.io/hashicorp/consul-ecs/aws//modules/mesh-task | 0.4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | registry.terraform.io/terraform-aws-modules/vpc/aws | 2.78.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_service.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_iam_policy.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.example_client_app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.hashicups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_route.private_to_hvn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.public_to_hvn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_secretsmanager_secret.bootstrap_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.consul_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.gossip_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.bootstrap_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.consul_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.gossip_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.example_client_app_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.ingress_from_client_alb_to_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_vpc_peering_connection_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
+| [consul_config_entry.deny_all](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.payments_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.postgres_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.product-api](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.product_api_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [consul_config_entry.public_api_intentions](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/resources/config_entry) | resource |
+| [hcp_aws_network_peering.default](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/aws_network_peering) | resource |
+| [hcp_consul_cluster.example](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/consul_cluster) | resource |
+| [hcp_hvn.server](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn) | resource |
+| [hcp_hvn_route.peering_route](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/hvn_route) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_ecs_task_definition.tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
+| [aws_security_group.vpc_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_logs_group"></a> [aws\_logs\_group](#input\_aws\_logs\_group) | n/a | `string` | `"hashicups"` | no |
+| <a name="input_capacity_providers"></a> [capacity\_providers](#input\_capacity\_providers) | n/a | `list(string)` | <pre>[<br>  "FARGATE"<br>]</pre> | no |
+| <a name="input_cluster_cidrs"></a> [cluster\_cidrs](#input\_cluster\_cidrs) | n/a | `any` | <pre>{<br>  "ecs_cluster": {<br>    "cidr_block": "10.0.0.0/16",<br>    "name": "ecs_cluster_one",<br>    "private_subnets": [<br>      "10.0.1.0/24",<br>      "10.0.2.0/24",<br>      "10.0.3.0/24"<br>    ],<br>    "public_subnets": [<br>      "10.0.4.0/24",<br>      "10.0.5.0/24",<br>      "10.0.6.0/24"<br>    ]<br>  }<br>}</pre> | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default Tags for AWS | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Team": "Education-Consul",<br>  "tutorial": "Serverless Consul service mesh with ECS and HCP"<br>}</pre> | no |
+| <a name="input_ecs_clusters"></a> [ecs\_clusters](#input\_ecs\_clusters) | n/a | `list` | <pre>[<br>  {<br>    "name": "cluster-one"<br>  },<br>  {<br>    "name": "cluster-two"<br>  }<br>]</pre> | no |
+| <a name="input_hashicups_settings"></a> [hashicups\_settings](#input\_hashicups\_settings) | n/a | `list` | <pre>[<br>  {<br>    "environment": [],<br>    "image": "hashicorpdemoapp/frontend:v1.0.3",<br>    "name": "frontend",<br>    "portMappings": [<br>      {<br>        "containerPort": 3000,<br>        "hostPort": 3000,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "public-api",<br>        "localBindPort": 8081<br>      }<br>    ]<br>  },<br>  {<br>    "environment": [],<br>    "image": "hashicorpdemoapp/payments:v0.0.16",<br>    "name": "payments",<br>    "portMappings": [<br>      {<br>        "containerPort": 8080,<br>        "hostPort": 8080,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "POSTGRES_DB",<br>        "value": "products"<br>      },<br>      {<br>        "name": "POSTGRES_USER",<br>        "value": "postgres"<br>      },<br>      {<br>        "name": "POSTGRES_PASSWORD",<br>        "value": "password"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/product-api-db:v0.0.21",<br>    "name": "postgres",<br>    "portMappings": [<br>      {<br>        "containerPort": 5432,<br>        "hostPort": 5432,<br>        "protocol": "tcp"<br>      }<br>    ],<br>    "upstreams": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "DB_CONNECTION",<br>        "value": "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable"<br>      },<br>      {<br>        "name": "METRICS_ADDRESS",<br>        "value": ":9103"<br>      },<br>      {<br>        "name": "BIND_ADDRESS",<br>        "value": ":9090"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/product-api:v0.0.21",<br>    "name": "product-api",<br>    "portMappings": [<br>      {<br>        "containerPort": 9090,<br>        "hostPort": 9090,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "postgres",<br>        "localBindPort": 5432<br>      }<br>    ],<br>    "volumes": []<br>  },<br>  {<br>    "environment": [<br>      {<br>        "name": "BIND_ADDRESS",<br>        "value": ":8081"<br>      },<br>      {<br>        "name": "PRODUCT_API_URI",<br>        "value": "http://localhost:9090"<br>      },<br>      {<br>        "name": "PAYMENT_API_URI",<br>        "value": "http://localhost:1800"<br>      }<br>    ],<br>    "image": "hashicorpdemoapp/public-api:v0.0.6",<br>    "name": "public-api",<br>    "portMappings": [<br>      {<br>        "containerPort": 8081,<br>        "hostPort": 8081,<br>        "protocol": "http"<br>      }<br>    ],<br>    "upstreams": [<br>      {<br>        "destinationName": "product-api",<br>        "localBindPort": 9090<br>      }<br>    ]<br>  }<br>]</pre> | no |
+| <a name="input_hcp_datacenter_name"></a> [hcp\_datacenter\_name](#input\_hcp\_datacenter\_name) | The name of datacenter the Consul cluster belongs to | `string` | `"dc1"` | no |
+| <a name="input_hvn_settings"></a> [hvn\_settings](#input\_hvn\_settings) | n/a | `map` | <pre>{<br>  "cidr_block": "172.25.16.0/20",<br>  "cloud_provider": {<br>    "aws": "aws"<br>  },<br>  "name": {<br>    "main-hvn": "main-hvn"<br>  },<br>  "region": {<br>    "us-east-1": "us-east-1"<br>  }<br>}</pre> | no |
+| <a name="input_lb_ingress_ip"></a> [lb\_ingress\_ip](#input\_lb\_ingress\_ip) | Your Public IP. This is used in the load balancer security groups to ensure only you can access the Consul UI and example application. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier. | `string` | `"consul-ecs-hashicups"` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `"us-east-1"` | no |
+| <a name="input_target_group_settings"></a> [target\_group\_settings](#input\_target\_group\_settings) | n/a | `map` | <pre>{<br>  "elb": {<br>    "services": [<br>      {<br>        "deregistration_delay": 30,<br>        "health": {<br>          "healthy_threshold": 2,<br>          "interval": 30,<br>          "path": "/",<br>          "timeout": 29,<br>          "unhealthy_threshold": 2<br>        },<br>        "name": "frontend",<br>        "port": "80",<br>        "protocol": "HTTP",<br>        "service_type": "http",<br>        "target_group_type": "ip"<br>      },<br>      {<br>        "deregistration_delay": 30,<br>        "health": {<br>          "healthy_threshold": 2,<br>          "interval": 30,<br>          "path": "/",<br>          "port": "8081",<br>          "timeout": 29,<br>          "unhealthy_threshold": 2<br>        },<br>        "name": "public-api",<br>        "port": "8081",<br>        "protocol": "HTTP",<br>        "service_type": "http",<br>        "target_group_type": "ip"<br>      }<br>    ]<br>  }<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_client_lb_address"></a> [client\_lb\_address](#output\_client\_lb\_address) | n/a |
+| <a name="output_consul_ui_address"></a> [consul\_ui\_address](#output\_consul\_ui\_address) | n/a |

--- a/terraform-ecs-hcp/aws-ecs_cluster.tf
+++ b/terraform-ecs-hcp/aws-ecs_cluster.tf
@@ -1,0 +1,5 @@
+resource "aws_ecs_cluster" "this" {
+  #for_each          = var.ecs_clusters
+  name               = var.name
+  capacity_providers = var.capacity_providers
+}

--- a/terraform-ecs-hcp/aws-iam.tf
+++ b/terraform-ecs-hcp/aws-iam.tf
@@ -1,0 +1,69 @@
+# Needed for the task definition to be able to write logs to Cloudwatch.
+resource "aws_iam_role" "hashicups" {
+  name = "hashicupsLogs"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          #"AWS" = ["arn:aws:iam::561656980159:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"]
+          "AWS" = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS"]
+        }
+        Action = "sts:AssumeRole"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "hashicups" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["secretsmanager:GetSecretValue"]
+        Effect = "Allow"
+        Resource = [
+          aws_secretsmanager_secret.gossip_key.arn,
+          aws_secretsmanager_secret.bootstrap_token.arn,
+          aws_secretsmanager_secret.consul_ca_cert.arn,
+          aws_lb.example_client_app.arn
+        ]
+      },
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvent"
+        ],
+        Effect   = "Allow"
+        Resource = ["*"]
+      },
+      {
+        Action = ["elasticloadbalancing:*"]
+        Effect = "Allow"
+        Resource = [
+          aws_lb.example_client_app.arn
+        ]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "hashicups" {
+  policy_arn = aws_iam_policy.hashicups.arn
+  role       = aws_iam_role.hashicups.name
+}

--- a/terraform-ecs-hcp/aws-load_balancer.tf
+++ b/terraform-ecs-hcp/aws-load_balancer.tf
@@ -1,0 +1,42 @@
+locals {
+  load_balancer_name         = var.name
+  load_balancer_target_group = "${var.name}-target-group"
+}
+
+resource "aws_lb" "example_client_app" {
+  name               = local.load_balancer_name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.example_client_app_alb.id]
+  subnets            = module.vpc.public_subnets
+}
+
+resource "aws_lb_target_group" "hashicups" {
+  for_each             = { for service in var.target_group_settings.elb.services : service.name => service }
+  name                 = each.value.name
+  port                 = each.value.port
+  protocol             = each.value.protocol
+  target_type          = each.value.target_group_type
+  vpc_id               = module.vpc.vpc_id
+  deregistration_delay = 10
+  health_check {
+    path                = "/"
+    healthy_threshold   = 2
+    unhealthy_threshold = 10
+    timeout             = 30
+    interval            = 60
+    // Try function added due to public-api not listening on the default traffic ports but port 8080
+    port                = try(each.value.health.port, "traffic-port")
+  }
+}
+
+resource "aws_lb_listener" "hashicups" {
+  for_each          = aws_lb_target_group.hashicups
+  load_balancer_arn = aws_lb.example_client_app.arn
+  port              = each.value.port
+  protocol          = each.value.protocol
+  default_action {
+    type             = "forward"
+    target_group_arn = each.value.arn
+  }
+}

--- a/terraform-ecs-hcp/aws-secrets_manager.tf
+++ b/terraform-ecs-hcp/aws-secrets_manager.tf
@@ -1,0 +1,36 @@
+locals {
+  name                 = var.name
+  bootstrap_token_name = "${local.name}-bootstrap-token"
+  gossip_key_name      = "${local.name}-gossip-key"
+  consul_ca_cert_name  = "${local.name}-consul-ca-cert"
+}
+
+resource "aws_secretsmanager_secret" "bootstrap_token" {
+  name                    = local.bootstrap_token_name
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "bootstrap_token" {
+  secret_id     = aws_secretsmanager_secret.bootstrap_token.id
+  secret_string = hcp_consul_cluster.example.consul_root_token_secret_id
+}
+
+resource "aws_secretsmanager_secret" "gossip_key" {
+  name                    = local.gossip_key_name
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "gossip_key" {
+  secret_id     = aws_secretsmanager_secret.gossip_key.id
+  secret_string = jsondecode(base64decode(hcp_consul_cluster.example.consul_config_file))["encrypt"]
+}
+
+resource "aws_secretsmanager_secret" "consul_ca_cert" {
+  name                    = local.consul_ca_cert_name
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "consul_ca_cert" {
+  secret_id     = aws_secretsmanager_secret.consul_ca_cert.id
+  secret_string = base64decode(hcp_consul_cluster.example.consul_ca_file)
+}

--- a/terraform-ecs-hcp/aws-security_groups.tf
+++ b/terraform-ecs-hcp/aws-security_groups.tf
@@ -1,0 +1,64 @@
+locals {
+  # In the future, if this value changes from var.name to var.foo, you will
+  # only update this "pointer" value to the new variable name, instead of updating
+  # every reference if using this variable multiple times.
+  local_name                   = var.name
+  security_group_name          = "example-client-app-alb"
+  security_group_resource_name = "${local.name}-${local.security_group_name}"
+  ingress_cidr_block           = "${var.lb_ingress_ip}/32"
+  egress_cidr_block            = "0.0.0.0/0"
+}
+
+
+resource "aws_security_group" "example_client_app_alb" {
+  name   = local.security_group_resource_name
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    description = "Access to example client application."
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0", local.ingress_cidr_block]
+  }
+
+  ingress {
+    description = "Access to example client application."
+    from_port   = 8081
+    to_port     = 8081
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0", local.ingress_cidr_block]
+  }
+
+  ingress {
+    description = "Access to example client application."
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    self        = true
+  }
+
+  ingress {
+    description = "Access to example client application."
+    from_port   = 8081
+    to_port     = 8081
+    protocol    = "tcp"
+    self        = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [local.egress_cidr_block]
+  }
+}
+
+resource "aws_security_group_rule" "ingress_from_client_alb_to_ecs" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.example_client_app_alb.id
+  security_group_id        = data.aws_security_group.vpc_default.id
+}

--- a/terraform-ecs-hcp/aws-vpc.tf
+++ b/terraform-ecs-hcp/aws-vpc.tf
@@ -1,0 +1,13 @@
+module "vpc" {
+  source  = "registry.terraform.io/terraform-aws-modules/vpc/aws"
+  version = "2.78.0"
+
+  name                 = var.cluster_cidrs.ecs_cluster.name
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = var.cluster_cidrs.ecs_cluster.private_subnets
+  public_subnets       = var.cluster_cidrs.ecs_cluster.public_subnets
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+}

--- a/terraform-ecs-hcp/consul-hcp_consul.tf
+++ b/terraform-ecs-hcp/consul-hcp_consul.tf
@@ -1,0 +1,7 @@
+resource "hcp_consul_cluster" "example" {
+  cluster_id      = var.hcp_datacenter_name
+  hvn_id          = hcp_hvn.server.hvn_id
+  tier            = "development"
+  public_endpoint = true
+  connect_enabled = true
+}

--- a/terraform-ecs-hcp/consul-hcp_hvn.tf
+++ b/terraform-ecs-hcp/consul-hcp_hvn.tf
@@ -1,0 +1,6 @@
+resource "hcp_hvn" "server" {
+  hvn_id         = var.hvn_settings.name.main-hvn
+  cloud_provider = var.hvn_settings.cloud_provider.aws
+  region         = var.hvn_settings.region.us-east-1
+  cidr_block     = var.hvn_settings.cidr_block
+}

--- a/terraform-ecs-hcp/consul-service_defaults.tf
+++ b/terraform-ecs-hcp/consul-service_defaults.tf
@@ -1,0 +1,8 @@
+resource "consul_config_entry" "product-api" {
+  name = "product-api"
+  kind = "service-defaults"
+
+  config_json = jsonencode({
+    Protocol = "tcp"
+  })
+}

--- a/terraform-ecs-hcp/consul-service_intentions.tf
+++ b/terraform-ecs-hcp/consul-service_intentions.tf
@@ -1,0 +1,95 @@
+locals {
+  public_api_name  = "public-api"
+  frontend_name    = "frontend"
+  product_api_name = "product-api"
+  postgres_name    = "postgres"
+  payments_name    = "payments"
+}
+
+resource "consul_config_entry" "product_api_intentions" {
+  name = local.product_api_name
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = local.public_api_name
+        Precedence = 9
+        Type       = "consul"
+        Namespace  = "default"
+      }
+    ]
+  })
+}
+
+resource "consul_config_entry" "public_api_intentions" {
+  name = local.public_api_name
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = local.frontend_name
+        Precedence = 9
+        Type       = "consul"
+        Namespace  = "default"
+      }
+    ]
+  })
+}
+
+
+resource "consul_config_entry" "deny_all" {
+  name = "*"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "deny"
+        Name       = "*"
+        Precedence = 9
+        Type       = "consul"
+        Namespace  = "default"
+      }
+    ]
+  })
+}
+
+resource "consul_config_entry" "payments_intentions" {
+  name = local.payments_name
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = local.public_api_name
+        Precedence = 9
+        Type       = "consul"
+        Namespace  = "default"
+      }
+    ]
+  })
+}
+
+
+resource "consul_config_entry" "postgres_intentions" {
+  name = local.postgres_name
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = local.product_api_name
+        Precedence = 9
+        Type       = "consul"
+        Namespace  = "default"
+      }
+    ]
+  })
+}
+

--- a/terraform-ecs-hcp/data.tf
+++ b/terraform-ecs-hcp/data.tf
@@ -1,0 +1,15 @@
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_caller_identity" "this" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_security_group" "vpc_default" {
+  name   = "default"
+  vpc_id = module.vpc.vpc_id
+}

--- a/terraform-ecs-hcp/hashicups.tf
+++ b/terraform-ecs-hcp/hashicups.tf
@@ -1,0 +1,165 @@
+locals {
+  task_names = [
+    for t in var.hashicups_settings : t.name
+  ]
+
+  needs_target = [
+    for c in var.hashicups_settings : c if c.name == "frontend" || c.name == "public-api"
+  ]
+
+  entities = [
+    for n in local.needs_target : {
+      container_name = n.name
+      container_port = n.portMappings[0].containerPort
+      target_group   = aws_lb_target_group.hashicups[n.name].arn
+    }
+  ]
+}
+
+module "acl_controller" {
+  source  = "registry.terraform.io/hashicorp/consul-ecs/aws//modules/acl-controller"
+  version = "0.4.0"
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = var.aws_logs_group #aws_cloudwatch_log_group.log_group.name
+      awslogs-region        = var.region
+      awslogs-stream-prefix = "consul-acl-controller"
+    }
+  }
+  consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
+  consul_server_http_addr           = hcp_consul_cluster.example.consul_public_endpoint_url
+  ecs_cluster_arn                   = aws_ecs_cluster.this.arn
+  region                            = var.region
+  subnets                           = module.vpc.private_subnets
+  name_prefix                       = var.name
+}
+
+module "hashicups-tasks" {
+  for_each = { for service in var.hashicups_settings : service.name => service }
+  source   = "registry.terraform.io/hashicorp/consul-ecs/aws//modules/mesh-task"
+  version  = "0.4.0"
+
+  family = each.value.name
+  port   = each.value.portMappings[0].hostPort #9090
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = "hashicups-ecs"
+      awslogs-region        = "us-east-1"
+      awslogs-stream-prefix = each.value.name
+      awslogs-create-group  = "true"
+    }
+  }
+  container_definitions = [{
+    name      = each.value.name
+    image     = each.value.image
+    essential = true
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = "hashicups-ecs-apps"
+        awslogs-region        = "us-east-1"
+        awslogs-stream-prefix = each.value.name
+        awslogs-create-group  = "true"
+      }
+    }
+    # Create the environment variables so that the frontend is loaded with the environment variable needed to communicate with public-api
+    environment = each.value.name == "frontend" ? concat(each.value.environment,
+      [
+        {
+          name = "NEXT_PUBLIC_PUBLIC_API_URL",
+          #value = "${hcp_consul_cluster.example.consul_public_endpoint_url}:8081"
+          value = "http://${aws_lb.example_client_app.dns_name}:8081"
+        },
+        {
+          name  = "NAME"
+          value = "${var.name}-${each.value.name}"
+        }
+        # The else of the ternary begins here. Add the NAME key for the rest of the task definitions.
+      ]) : concat(each.value.environment,
+      [{
+        name  = "NAME"
+        value = "${var.name}-${each.value.name}"
+    }])
+    portMappings = [
+      {
+        containerPort = each.value.portMappings[0].containerPort
+        hostPort      = each.value.portMappings[0].hostPort
+        protocol      = each.value.portMappings[0].protocol
+      }
+    ]
+    cpu         = 0
+    mountPoints = []
+    volumesFrom = []
+  }]
+  upstreams = length(each.value.upstreams) > 0 ? each.value.upstreams : []
+  #  upstreams = [
+  #    {
+  #      destination_name = each.value#"${var.name}-example-server-app"
+  #      local_bind_port  = 1234
+  #    },
+  #
+  #  ]
+  retry_join                     = jsondecode(base64decode(hcp_consul_cluster.example.consul_config_file))["retry_join"]
+  tls                            = true
+  consul_server_ca_cert_arn      = aws_secretsmanager_secret.consul_ca_cert.arn
+  gossip_key_secret_arn          = aws_secretsmanager_secret.gossip_key.arn
+  acls                           = true
+  consul_client_token_secret_arn = module.acl_controller.client_token_secret_arn
+  acl_secret_name_prefix         = var.name
+  consul_datacenter              = var.hcp_datacenter_name
+  consul_partition               = null
+  consul_namespace               = null
+  task_role = {
+    id  = each.value.name
+    arn = aws_iam_role.hashicups.arn
+  }
+  additional_execution_role_policies = [
+    aws_iam_policy.hashicups.arn
+  ]
+}
+
+
+# Next, map the ECS Task Definition's family name to the AWS ECS Service.
+# mesh-task doesn't directly provide the family name as an output, we use the data resource to lookup the value.
+
+data "aws_ecs_task_definition" "tasks" {
+  for_each = toset(local.task_names)
+  # each.value represents the readable name that the task_definition data resource uses to search for the task_definition.
+  task_definition = each.value
+
+  # There is no direct or indirect relationship to the mesh-task resource. We use the depends_on so
+  # the data resource doesn't attempt to lookup task names that have yet been created.
+  depends_on = [module.hashicups-tasks]
+}
+
+# this is where I moved entities
+
+resource "aws_ecs_service" "service" {
+  for_each        = data.aws_ecs_task_definition.tasks
+  name            = each.value.family
+  cluster         = aws_ecs_cluster.this.arn
+  task_definition = each.value.arn
+  desired_count   = 1
+  network_configuration {
+    # Only the frontend and public-api go into the public subnet with public IPs.
+    subnets          = each.value.family == "frontend" || each.value.family == "public-api" ? module.vpc.public_subnets : module.vpc.private_subnets
+    assign_public_ip = each.value.family == "frontend" || each.value.family == "public-api" ? true : false
+
+  }
+  launch_type    = "FARGATE"
+  propagate_tags = "TASK_DEFINITION"
+  dynamic "load_balancer" {
+    # Only configure load balancing targets for tasks that require it, namely, any entity present in the local.entities list that filters the required tasks.
+    # The for_each only runs when the container name and task definition match each other.
+    for_each = { for e in local.entities : e.container_name => e if each.value.task_definition == e.container_name }
+
+    content {
+      container_name   = each.value.task_definition
+      container_port   = load_balancer.value.container_port
+      target_group_arn = load_balancer.value.target_group
+    }
+  }
+  enable_execute_command = true
+}

--- a/terraform-ecs-hcp/hcp-network_peering.tf
+++ b/terraform-ecs-hcp/hcp-network_peering.tf
@@ -1,0 +1,37 @@
+locals {
+  peering_id           = "${hcp_hvn.server.hvn_id}-peering"
+  peering_id_hvn_route = "${local.peering_id}-route"
+}
+
+resource "hcp_aws_network_peering" "default" {
+  peering_id      = local.peering_id
+  hvn_id          = hcp_hvn.server.hvn_id
+  peer_vpc_id     = module.vpc.vpc_id
+  peer_account_id = data.aws_caller_identity.current.account_id
+  peer_vpc_region = var.region
+}
+
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  vpc_peering_connection_id = hcp_aws_network_peering.default.provider_peering_id
+  auto_accept               = true
+}
+
+resource "hcp_hvn_route" "peering_route" {
+  hvn_link         = hcp_hvn.server.self_link
+  hvn_route_id     = local.peering_id_hvn_route
+  destination_cidr = module.vpc.vpc_cidr_block
+  target_link      = hcp_aws_network_peering.default.self_link
+
+}
+
+resource "aws_route" "public_to_hvn" {
+  route_table_id            = module.vpc.public_route_table_ids[0]
+  destination_cidr_block    = hcp_hvn.server.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.vpc_peering_connection_id
+}
+
+resource "aws_route" "private_to_hvn" {
+  route_table_id            = module.vpc.private_route_table_ids[0]
+  destination_cidr_block    = hcp_hvn.server.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.vpc_peering_connection_id
+}

--- a/terraform-ecs-hcp/outputs.tf
+++ b/terraform-ecs-hcp/outputs.tf
@@ -1,0 +1,7 @@
+output "client_lb_address" {
+  value = "http://${aws_lb.example_client_app.dns_name}:9090/ui"
+}
+
+output "consul_ui_address" {
+  value = hcp_consul_cluster.example.consul_public_endpoint_url
+}

--- a/terraform-ecs-hcp/providers.tf
+++ b/terraform-ecs-hcp/providers.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">3.0.0"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.14.0"
+    }
+    consul = {
+      source  = "hashicorp/consul"
+      version = "~> 2.15.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = var.default_tags
+  }
+}
+
+provider "consul" {
+  address    = hcp_consul_cluster.example.consul_public_endpoint_url
+  token      = hcp_consul_cluster.example.consul_root_token_secret_id
+  datacenter = var.hcp_datacenter_name
+}
+
+provider "hcp" {}
+

--- a/terraform-ecs-hcp/terraform.tfvars.example
+++ b/terraform-ecs-hcp/terraform.tfvars.example
@@ -1,0 +1,3 @@
+lb_ingress_ip = "YOUR_PUBLIC_IP"
+region     = "us-east-1"
+name = "learn-hcp"

--- a/terraform-ecs-hcp/variables.tf
+++ b/terraform-ecs-hcp/variables.tf
@@ -1,0 +1,241 @@
+variable "name" {
+  description = "Name to be used on all the resources as identifier."
+  type        = string
+  default     = "consul-ecs-hashicups"
+}
+
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "lb_ingress_ip" {
+  description = "Your Public IP. This is used in the load balancer security groups to ensure only you can access the Consul UI and example application."
+  type        = string
+}
+
+variable "hcp_datacenter_name" {
+  type        = string
+  description = "The name of datacenter the Consul cluster belongs to"
+  default     = "dc1"
+}
+
+variable "default_tags" {
+  description = "Default Tags for AWS"
+  type        = map(string)
+  default = {
+    Environment = "dev"
+    Team        = "Education-Consul"
+    tutorial    = "Serverless Consul service mesh with ECS and HCP"
+  }
+}
+
+variable "hashicups_settings" {
+  default = [
+    {
+      name  = "frontend"
+      image = "hashicorpdemoapp/frontend:v1.0.3"
+      portMappings = [
+        {
+          containerPort = 3000
+          hostPort      = 3000
+          protocol      = "http"
+        }
+      ],
+      upstreams = [
+        {
+          destinationName = "public-api"
+          localBindPort   = 8081
+        }
+      ],
+      environment = []
+    },
+    {
+      name  = "payments"
+      image = "hashicorpdemoapp/payments:v0.0.16"
+      portMappings = [{
+        protocol      = "http"
+        containerPort = 8080
+        hostPort      = 8080
+      }]
+      upstreams   = []
+      environment = []
+    },
+    {
+      name  = "postgres"
+      image = "hashicorpdemoapp/product-api-db:v0.0.21"
+      environment = [{
+        name  = "POSTGRES_DB"
+        value = "products"
+        },
+        {
+          name  = "POSTGRES_USER"
+          value = "postgres"
+        },
+        {
+          name  = "POSTGRES_PASSWORD"
+          value = "password"
+      }]
+      portMappings = [{
+        protocol      = "tcp"
+        containerPort = 5432
+        hostPort      = 5432
+      }]
+      upstreams = []
+    },
+    {
+      name  = "product-api"
+      image = "hashicorpdemoapp/product-api:v0.0.21"
+      environment = [{
+        #        name = "CONFIG_FILE",
+        #        # Discrepancy in the repo: conf.json or config.json? Conf.json returns not found
+        #        # Ref: https://github.com/hashicorp-demoapp/product-api-go/blob/main/docker_compose/docker-compose.yml#L8
+        #        value = "./conf.json"
+        ##      },
+        #        {
+        name  = "DB_CONNECTION"
+        value = "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable"
+        },
+        {
+          name  = "METRICS_ADDRESS"
+          value = ":9103"
+        },
+        {
+          name  = "BIND_ADDRESS"
+          value = ":9090"
+      }]
+      portMappings = [{
+        protocol      = "http"
+        containerPort = 9090
+        hostPort      = 9090
+      }]
+      upstreams = [
+        {
+          destinationName = "postgres"
+          localBindPort   = 5432
+        },
+
+      ],
+      volumes = []
+    },
+    {
+      name  = "public-api"
+      image = "hashicorpdemoapp/public-api:v0.0.7"
+      environment = [{
+        # ECS only suports container/host port equality. Since payments also uses 8080, switch this to 8081.
+        # Ref: https://github.com/hashicorp-demoapp/public-api/blob/a576419df268b74966c4dfdb90d653f498026d6d/main.go#L30
+        name = "BIND_ADDRESS"
+        # We missed the colon here
+        value = ":8081"
+        },
+        {
+          name  = "PRODUCT_API_URI"
+          value = "http://localhost:9090"
+        },
+        {
+          name  = "PAYMENT_API_URI"
+          value = "http://localhost:1800"
+      }]
+      portMappings = [{
+        protocol      = "http"
+        containerPort = 8081
+        hostPort      = 8081
+      }]
+      upstreams = [{
+        destinationName = "product-api"
+        localBindPort   = 9090
+      }]
+    }
+  ]
+}
+
+variable "aws_logs_group" {
+  default = "hashicups"
+}
+
+variable "ecs_clusters" {
+  default = [
+    {
+      name = "cluster-one"
+    },
+    {
+      name = "cluster-two"
+    }
+
+  ]
+
+}
+
+variable "capacity_providers" {
+  type    = list(string)
+  default = ["FARGATE"]
+}
+
+variable "hvn_settings" {
+  default = {
+    name = {
+      main-hvn = "main-hvn"
+    }
+    cloud_provider = {
+      aws = "aws"
+    }
+    region = {
+      us-east-1 = "us-east-1"
+    }
+    cidr_block = "172.25.16.0/20"
+  }
+}
+
+
+variable "target_group_settings" {
+  default = {
+    elb = {
+      services = [
+        {
+          name                 = "frontend"
+          service_type         = "http"
+          protocol             = "HTTP"
+          target_group_type    = "ip"
+          port                 = "80"
+          deregistration_delay = 30
+          health = {
+            healthy_threshold   = 2
+            unhealthy_threshold = 2
+            interval            = 30
+            timeout             = 29
+            path                = "/"
+          }
+        },
+        {
+          name                 = "public-api"
+          service_type         = "http"
+          protocol             = "HTTP"
+          target_group_type    = "ip"
+          port                 = "8081"
+          deregistration_delay = 30
+          health = {
+            healthy_threshold   = 2
+            unhealthy_threshold = 2
+            interval            = 30
+            timeout             = 29
+            path                = "/"
+            port                = "8081"
+          },
+        },
+      ]
+    }
+  }
+}
+
+variable "cluster_cidrs" {
+  type = any
+  default = {
+    ecs_cluster = {
+      name       = "ecs_cluster_one"
+      cidr_block = "10.0.0.0/16"
+      private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+      public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+    },
+  }
+}


### PR DESCRIPTION
This PR adds an example setup for HashiCups that uses AWS ECS and HCP Consul.