### PR TITLE
fix: added serviceAccountName to postgres and public-api

### DIFF
--- a/local-k8s-consul-deployment/k8s/postgres.yaml
+++ b/local-k8s-consul-deployment/k8s/postgres.yaml
@@ -46,6 +46,7 @@ spec:
         prometheus.io/port: "9102"
         consul.hashicorp.com/connect-inject: "true"
     spec:
+      serviceAccountName: postgres
       containers:
         - name: postgres
           image: hashicorpdemoapp/product-api-db:v0.0.21

--- a/local-k8s-consul-deployment/k8s/public-api.yaml
+++ b/local-k8s-consul-deployment/k8s/public-api.yaml
@@ -45,6 +45,7 @@ spec:
         prometheus.io/port: "9102"
         consul.hashicorp.com/connect-inject: "true"
     spec:
+      serviceAccountName: public-api
       containers:
         - name: public-api
           image: hashicorpdemoapp/public-api:v0.0.6


### PR DESCRIPTION
added serviceAccountName to postgres and public-api, otherwise "default" is used.