### PR TITLE
update default Nomad datacenter to the wildcard value

### DIFF
--- a/nomad/hashicups.nomad
+++ b/nomad/hashicups.nomad
@@ -1,7 +1,7 @@
 variable "datacenters" {
   description = "A list of datacenters in the region which are eligible for task placement."
   type        = list(string)
-  default     = ["dc1"]
+  default     = ["*"]
 }
 
 variable "region" {


### PR DESCRIPTION
Using the wildcard datacenter ensures this sample job works in different environments.